### PR TITLE
Prevent unbound variable when running with no args

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
 
 if [ -n "${LD_LIBRARY_PATH:-}" ]; then
 	export LD_LIBRARY_PATH="${ASDF_INSTALL_PATH}/bin:${LD_LIBRARY_PATH}/lib"

--- a/bin/install
+++ b/bin/install
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -euo pipefail
-
 declare git_hash
 
 if [ "$ASDF_INSTALL_TYPE" = "version" ]; then


### PR DESCRIPTION
When running `janet` with no args you currently get:

```console
> asdf plugin add janet https://github.com/jakski/asdf-janet.git
> asdf install janet latest
[snip]
> asdf global janet latest
> which janet
<asdf_install_dir>/shims/janet

> janet
<asdf_install_dir>/lib/commands/command-exec.bash: line 23: shim_args[@]: unbound variable
```

With these changes:

```console
> asdf plugin add janet https://github.com/kiliantyler/asdf-janet.git
> asdf install janet latest
[snip]
> asdf global janet latest
> which janet
<asdf_install_dir>/shims/janet

> janet
Janet 1.35.2-meson macos/aarch64/clang - '(doc)' for help
repl:1:>
```


Ref:
https://github.com/code-lever/asdf-rust/issues/17
[code-lever/asdf-rust@`17a96bd` (#19)](https://github.com/code-lever/asdf-rust/pull/19/commits/17a96bd50ace13fda4a7648b4fd790043072be91)
